### PR TITLE
Adding an extremely unique tag 

### DIFF
--- a/log.js
+++ b/log.js
@@ -2,7 +2,7 @@ const { performance, PerformanceObserver } = require('perf_hooks')
 
 function log (event) {
   process.stdout.write(
-    JSON.stringify({
+    "FAASTERMETRICS" + JSON.stringify({
       timestamp: new Date().getTime(),
       now: performance.now(),
       ...event


### PR DESCRIPTION
We need this to reliably find our own log entries in the generated logs. With this, it should be possible for us to ignore formatting differences in AWS, Google and Azure, making analysis much much easier.